### PR TITLE
✨  feat : 특정 메뉴를 파는 가게 조회 API 구현

### DIFF
--- a/src/main/java/com/example/Centralthon/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/example/Centralthon/domain/menu/repository/MenuRepository.java
@@ -26,4 +26,6 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
             double maxLng
     );
 
+
+
 }

--- a/src/main/java/com/example/Centralthon/domain/menu/service/MenuService.java
+++ b/src/main/java/com/example/Centralthon/domain/menu/service/MenuService.java
@@ -1,9 +1,12 @@
 package com.example.Centralthon.domain.menu.service;
 
 import com.example.Centralthon.domain.menu.web.dto.NearbyMenusRes;
+import com.example.Centralthon.domain.menu.web.dto.StoresByMenu;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public interface MenuService {
     List<NearbyMenusRes> nearbyMenus(double latitude, double longitude);
+
+    List<StoresByMenu> storesByMenu(String name, double lat, double lng);
 }

--- a/src/main/java/com/example/Centralthon/domain/menu/service/MenuService.java
+++ b/src/main/java/com/example/Centralthon/domain/menu/service/MenuService.java
@@ -1,12 +1,12 @@
 package com.example.Centralthon.domain.menu.service;
 
 import com.example.Centralthon.domain.menu.web.dto.NearbyMenusRes;
-import com.example.Centralthon.domain.menu.web.dto.StoresByMenu;
+import com.example.Centralthon.domain.menu.web.dto.StoresByMenuRes;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public interface MenuService {
     List<NearbyMenusRes> nearbyMenus(double latitude, double longitude);
 
-    List<StoresByMenu> storesByMenu(String name, double lat, double lng);
+    List<StoresByMenuRes> storesByMenu(String name, double lat, double lng);
 }

--- a/src/main/java/com/example/Centralthon/domain/menu/service/MenuServiceImpl.java
+++ b/src/main/java/com/example/Centralthon/domain/menu/service/MenuServiceImpl.java
@@ -4,7 +4,7 @@ import com.example.Centralthon.domain.menu.entity.Menu;
 import com.example.Centralthon.domain.menu.exception.MenuNotFoundException;
 import com.example.Centralthon.domain.menu.repository.MenuRepository;
 import com.example.Centralthon.domain.menu.web.dto.NearbyMenusRes;
-import com.example.Centralthon.domain.menu.web.dto.StoresByMenu;
+import com.example.Centralthon.domain.menu.web.dto.StoresByMenuRes;
 import com.example.Centralthon.domain.store.entity.Store;
 import com.example.Centralthon.global.util.geo.BoundingBox;
 import com.example.Centralthon.global.util.geo.GeoUtils;
@@ -59,7 +59,7 @@ public class MenuServiceImpl implements MenuService {
 
     @Override
     @Transactional(readOnly=true)
-    public List<StoresByMenu> storesByMenu(String name, double lat, double lng) {
+    public List<StoresByMenuRes> storesByMenu(String name, double lat, double lng) {
         List<Menu> menus = findMenusWithinRadius(lat, lng);
 
         // 이름이 일치하는 메뉴만 필터링, 가격 오름차순 정렬
@@ -69,7 +69,7 @@ public class MenuServiceImpl implements MenuService {
                 .toList();
 
         return filtered.stream()
-                .map(menu -> StoresByMenu.from(
+                .map(menu -> StoresByMenuRes.from(
                         menu,
                         GeoUtils.calculateDistance(lat, lng, menu.getStore().getLatitude(), menu.getStore().getLongitude())
                 ))

--- a/src/main/java/com/example/Centralthon/domain/menu/service/MenuServiceImpl.java
+++ b/src/main/java/com/example/Centralthon/domain/menu/service/MenuServiceImpl.java
@@ -4,26 +4,30 @@ import com.example.Centralthon.domain.menu.entity.Menu;
 import com.example.Centralthon.domain.menu.exception.MenuNotFoundException;
 import com.example.Centralthon.domain.menu.repository.MenuRepository;
 import com.example.Centralthon.domain.menu.web.dto.NearbyMenusRes;
+import com.example.Centralthon.domain.menu.web.dto.StoresByMenu;
+import com.example.Centralthon.domain.store.entity.Store;
 import com.example.Centralthon.global.util.geo.BoundingBox;
+import com.example.Centralthon.global.util.geo.GeoUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 import static com.example.Centralthon.global.util.geo.GeoUtils.calculateBoundingBox;
+import static com.example.Centralthon.global.util.geo.GeoUtils.calculateDistance;
 
 @Service
 @RequiredArgsConstructor
 public class MenuServiceImpl implements MenuService {
     private final MenuRepository menuRepository;
 
-    @Override
-    @Transactional(readOnly=true)
-    public List<NearbyMenusRes> nearbyMenus(double latitude, double longitude) {
+    // 주어진 위도, 경도를 중심으로 반경 2km 이내의 메뉴 조회
+    private List<Menu> findMenusWithinRadius(double latitude, double longitude) {
         LocalDateTime now = LocalDateTime.now();
 
         // 사용자 위치를 기반으로 2km 반경의 Bounding Box 계산
@@ -34,6 +38,13 @@ public class MenuServiceImpl implements MenuService {
                 latitude, longitude, now,
                 bbox.minLat(), bbox.maxLat(), bbox.minLng(), bbox.maxLng()
         );
+        return menus;
+    }
+
+    @Override
+    @Transactional(readOnly=true)
+    public List<NearbyMenusRes> nearbyMenus(double latitude, double longitude) {
+        List<Menu> menus = findMenusWithinRadius(latitude, longitude);
 
         // 중복 메뉴 제거
         Map<String, Menu> uniqueMenus = new LinkedHashMap<>();
@@ -43,6 +54,25 @@ public class MenuServiceImpl implements MenuService {
 
         return uniqueMenus.values().stream()
                 .map(NearbyMenusRes::from)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly=true)
+    public List<StoresByMenu> storesByMenu(String name, double lat, double lng) {
+        List<Menu> menus = findMenusWithinRadius(lat, lng);
+
+        // 이름이 일치하는 메뉴만 필터링, 가격 오름차순 정렬
+        List<Menu> filtered = menus.stream()
+                .filter(m -> m.getName().equals(name))
+                .sorted(Comparator.comparingInt(Menu::getSalePrice))
+                .toList();
+
+        return filtered.stream()
+                .map(menu -> StoresByMenu.from(
+                        menu,
+                        GeoUtils.calculateDistance(lat, lng, menu.getStore().getLatitude(), menu.getStore().getLongitude())
+                ))
                 .toList();
     }
 }

--- a/src/main/java/com/example/Centralthon/domain/menu/web/controller/MenuController.java
+++ b/src/main/java/com/example/Centralthon/domain/menu/web/controller/MenuController.java
@@ -2,6 +2,7 @@ package com.example.Centralthon.domain.menu.web.controller;
 
 import com.example.Centralthon.domain.menu.service.MenuService;
 import com.example.Centralthon.domain.menu.web.dto.NearbyMenusRes;
+import com.example.Centralthon.domain.menu.web.dto.StoresByMenu;
 import com.example.Centralthon.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -26,5 +27,17 @@ public class MenuController {
         List<NearbyMenusRes> menus = menuService.nearbyMenus(lat,lng);
 
         return ResponseEntity.status(HttpStatus.OK).body(SuccessResponse.from(menus));
+    }
+
+    //특정 메뉴를 판매 하는 가게 조회
+    @GetMapping("/stores")
+    public ResponseEntity<SuccessResponse<List<StoresByMenu>>> storesByMenu(
+            @RequestParam("name") String name,
+            @RequestParam("lat") Double lat,
+            @RequestParam("lng") Double lng) {
+
+        List<StoresByMenu> stores = menuService.storesByMenu(name,lat,lng);
+
+        return ResponseEntity.status(HttpStatus.OK).body(SuccessResponse.from(stores));
     }
 }

--- a/src/main/java/com/example/Centralthon/domain/menu/web/controller/MenuController.java
+++ b/src/main/java/com/example/Centralthon/domain/menu/web/controller/MenuController.java
@@ -2,7 +2,7 @@ package com.example.Centralthon.domain.menu.web.controller;
 
 import com.example.Centralthon.domain.menu.service.MenuService;
 import com.example.Centralthon.domain.menu.web.dto.NearbyMenusRes;
-import com.example.Centralthon.domain.menu.web.dto.StoresByMenu;
+import com.example.Centralthon.domain.menu.web.dto.StoresByMenuRes;
 import com.example.Centralthon.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -31,12 +31,12 @@ public class MenuController {
 
     //특정 메뉴를 판매 하는 가게 조회
     @GetMapping("/stores")
-    public ResponseEntity<SuccessResponse<List<StoresByMenu>>> storesByMenu(
+    public ResponseEntity<SuccessResponse<List<StoresByMenuRes>>> storesByMenu(
             @RequestParam("name") String name,
             @RequestParam("lat") Double lat,
             @RequestParam("lng") Double lng) {
 
-        List<StoresByMenu> stores = menuService.storesByMenu(name,lat,lng);
+        List<StoresByMenuRes> stores = menuService.storesByMenu(name,lat,lng);
 
         return ResponseEntity.status(HttpStatus.OK).body(SuccessResponse.from(stores));
     }

--- a/src/main/java/com/example/Centralthon/domain/menu/web/dto/StoresByMenu.java
+++ b/src/main/java/com/example/Centralthon/domain/menu/web/dto/StoresByMenu.java
@@ -1,0 +1,22 @@
+package com.example.Centralthon.domain.menu.web.dto;
+
+import com.example.Centralthon.domain.menu.entity.Menu;
+import com.example.Centralthon.domain.menu.entity.enums.MenuCategory;
+import com.example.Centralthon.domain.store.entity.Store;
+
+public record StoresByMenu(
+        String storeName,
+        double distance,
+        int salePrice,
+        int quantity
+) {
+    public static StoresByMenu from(Menu menu, double distance) {
+        Store store = menu.getStore();
+        return new StoresByMenu(
+                store.getName(),
+                distance,
+                menu.getSalePrice(),
+                menu.getQuantity()
+        );
+    }
+}

--- a/src/main/java/com/example/Centralthon/domain/menu/web/dto/StoresByMenuRes.java
+++ b/src/main/java/com/example/Centralthon/domain/menu/web/dto/StoresByMenuRes.java
@@ -5,6 +5,7 @@ import com.example.Centralthon.domain.menu.entity.enums.MenuCategory;
 import com.example.Centralthon.domain.store.entity.Store;
 
 public record StoresByMenuRes(
+        long menuId,
         String storeName,
         double distance,
         int salePrice,
@@ -13,6 +14,7 @@ public record StoresByMenuRes(
     public static StoresByMenuRes from(Menu menu, double distance) {
         Store store = menu.getStore();
         return new StoresByMenuRes(
+                menu.getId(),
                 store.getName(),
                 distance,
                 menu.getSalePrice(),

--- a/src/main/java/com/example/Centralthon/domain/menu/web/dto/StoresByMenuRes.java
+++ b/src/main/java/com/example/Centralthon/domain/menu/web/dto/StoresByMenuRes.java
@@ -4,15 +4,15 @@ import com.example.Centralthon.domain.menu.entity.Menu;
 import com.example.Centralthon.domain.menu.entity.enums.MenuCategory;
 import com.example.Centralthon.domain.store.entity.Store;
 
-public record StoresByMenu(
+public record StoresByMenuRes(
         String storeName,
         double distance,
         int salePrice,
         int quantity
 ) {
-    public static StoresByMenu from(Menu menu, double distance) {
+    public static StoresByMenuRes from(Menu menu, double distance) {
         Store store = menu.getStore();
-        return new StoresByMenu(
+        return new StoresByMenuRes(
                 store.getName(),
                 distance,
                 menu.getSalePrice(),

--- a/src/main/java/com/example/Centralthon/global/util/geo/GeoUtils.java
+++ b/src/main/java/com/example/Centralthon/global/util/geo/GeoUtils.java
@@ -3,6 +3,7 @@ package com.example.Centralthon.global.util.geo;
 public class GeoUtils {
     private static final double R = 6371.0; // 지구 반경 (km)
 
+    // 거리 반경 지정
     public static BoundingBox calculateBoundingBox(double lat, double lng, double radiusKm) {
         // Bounding Box 계산 로직
         double latRadius = Math.toDegrees(radiusKm / R);
@@ -14,5 +15,16 @@ public class GeoUtils {
         double maxLng = lng + lngRadius;
 
         return new BoundingBox(minLat, maxLat, minLng, maxLng);
+    }
+
+    // 거리 계산
+    public static double calculateDistance(double lat1, double lng1, double lat2, double lng2) {
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLng = Math.toRadians(lng2 - lng1);
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(dLng / 2) * Math.sin(dLng / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return R * c;
     }
 }


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->
- close #9
<br>

## ✅ 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 기능 수정

<br>

## ✨ 작업 내용
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->
- 특정 메뉴를 파는 가게 조회 API 구현
<br>

## 👥 전달사항
<!--
1. User 도메인 구조를 변경하였습니다.
2. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->
1. 현재 가게 리스트는 반찬 가격을 기준, 오름차순으로 정렬됩니다.
2. MenuServiceImpl에서 2km 반경내에 메뉴를 가져오는 로직이 중복 되어 공통 메서드로 분리했습니다.
3. 기존 menu_id를 넘겨주는 부분이 없어서 메뉴  상세 조회 시, 가게와 반찬명으로 탐색해야 하기에 menu_id를 반환하도록 변경하였습니다.
<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="951" height="1224" alt="image" src="https://github.com/user-attachments/assets/27dc4d56-05af-4d01-8890-d690fa372221" />
